### PR TITLE
Add language icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
         "extensions": [
           ".roc"
         ],
-        "configuration": "./roc-language-configuration.json"
+        "configuration": "./roc-language-configuration.json",
+        "icon": {
+          "dark": "./resources/roc-logo.png",
+          "light": "./resources/roc-logo.png"
+        }
       }
     ],
     "grammars": [


### PR DESCRIPTION
Associates the Roc icon with the `.roc` file type.