### PR TITLE
Fix comment highlighting

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -79,7 +79,7 @@
     "comments": {
       "patterns": [
         {
-          "begin": "# ",
+          "begin": "#",
           "end": "$",
           "name": "comment.line.number-sign.roc",
           "captures": {
@@ -89,7 +89,7 @@
           }
         },
         {
-          "begin": "## ",
+          "begin": "##",
           "end": "$",
           "name": "comment.block.documentation.roc",
           "captures": {


### PR DESCRIPTION
Comments should have a space after the `# ` or `## ` when `roc format` is called, but they don't always. This fixes the syntax highlighting to always highlight comments, even if the space is missing. :)