### PR TITLE
Fix extension display name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "roc-lang-unofficial",
   "version": "0.0.5",
   "icon": "resources/roc-logo.png",
-  "displayName": "roc-lang-unofficial",
+  "displayName": "Roc (Unofficial)",
   "description": "Roc language support",
   "publisher": "IvanDemchenko",
   "pricing": "Free",


### PR DESCRIPTION
Last PR! The display name is the name that VSCode shows in the marketplace and can contain spaces and punctuation.