### PR TITLE
Fix scientific notation highlighting

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -51,7 +51,7 @@
       ]
     },
     "numbers_float": {
-      "match": "\\b([0-9]+\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\\b",
+      "match": "\\b([0-9]+\\.[0-9]+(e-?[0-9]+)?|[0-9]+e-?[0-9]+)\\b",
       "name": "constant.numeric.float.roc"
     },
     "numbers_int": {


### PR DESCRIPTION
Roc doesn't allow capital `E` for scientific notation (e.g. `1E5`), and doesn't allow a `+` in scientific notation either (e.g. `1e+5`). This PR removes both of those from the float highlighting pattern.