### PR TITLE
Add underscore highlighting to number literals

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -51,11 +51,11 @@
       ]
     },
     "numbers_float": {
-      "match": "\\b([0-9]+\\.[0-9]+(e-?[0-9]+)?|[0-9]+e-?[0-9]+)\\b",
+      "match": "\\b([0-9][0-9_]*\\.[0-9_]+(e-?[0-9_]+)?|[0-9][0-9_]*e-?[0-9][0-9_]*)\\b",
       "name": "constant.numeric.float.roc"
     },
     "numbers_int": {
-      "match": "\\b([0-9]+)\\b",
+      "match": "\\b([0-9][0-9_]*)\\b",
       "name": "constant.numeric.roc"
     },
     "numbers": {


### PR DESCRIPTION
Number literals can have underscores in some parts, e.g. `123_456` or `123_456.789_123` or `123e1_2`.