### PR TITLE
Add "as" keyword

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -8,7 +8,7 @@
       "name": "keyword.unused.roc"
     },
     {
-      "match": "\\b(dbg|if|then|else|when|is|app|packages|imports|provides|to)\\s+",
+      "match": "\\b(dbg|if|then|else|when|is|app|packages|imports|provides|to|as)\\s+",
       "name": "keyword.control.roc"
     },
     { "include": "#comments" },


### PR DESCRIPTION
The `as` keyword is used in pattern matching:

```coffee
foo =
    when [1, 2, 3, 4] is
        [1, .. as b] -> b
        _ -> []
```