### PR TITLE
Add support for single quoted strings

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -101,27 +101,56 @@
       ]
     },
     "strings": {
-      "name": "string.quoted.double.roc",
-      "begin": "\"",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.roc"
-        }
-      },
-      "end": "\"",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.roc"
-        }
-      },
       "patterns": [
         {
-          "match": "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&]|x[0-9a-fA-F]{1,5})",
-          "name": "constant.character.escape.roc"
+          "name": "string.quoted.double.roc",
+          "begin": "\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.roc"
+            }
+          },
+          "end": "\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.roc"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&]|x[0-9a-fA-F]{1,5})",
+              "name": "constant.character.escape.roc"
+            },
+            {
+              "match": "\\^[A-Z@\\[\\]\\\\\\^_]",
+              "name": "constant.character.escape.control.roc"
+            }
+          ]
         },
         {
-          "match": "\\^[A-Z@\\[\\]\\\\\\^_]",
-          "name": "constant.character.escape.control.roc"
+          "name": "string.quoted.single.roc",
+          "begin": "'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.roc"
+            }
+          },
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.roc"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&]|x[0-9a-fA-F]{1,5})",
+              "name": "constant.character.escape.roc"
+            },
+            {
+              "match": "\\^[A-Z@\\[\\]\\\\\\^_]",
+              "name": "constant.character.escape.control.roc"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION

## Description

As reported by @lukewilliamboswell on Zulip.

Before:
![image](https://github.com/raqystyle/roc-vscode-unofficial/assets/25184102/319a82c1-3883-48be-acb2-1e8eca18f640)

After:
![image](https://github.com/raqystyle/roc-vscode-unofficial/assets/25184102/bda5de5b-a26c-4c2d-8419-b93c920c13a2)

## Checklist

- [x] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
